### PR TITLE
Update to recent cobs.rs (nee postcard-cobs) release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,7 @@ std = []
 [dev-dependencies]
 criterion = "0.3.5"
 cobs-rs = "1.1"
-postcard-cobs = "0.2"
-cobs = "0.1"
+cobs = "0.2.1"
 
 [profile.release]
 debug = 2

--- a/benches/comparison.rs
+++ b/benches/comparison.rs
@@ -23,8 +23,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         });
 
         let mut out = [0; corncobs::max_encoded_len(FIXED_LEN)];
-        group.bench_with_input(BenchmarkId::new("postcard-cobs", set), data, move |b, i| {
-            b.iter(|| postcard_cobs::encode(i, &mut out));
+        group.bench_with_input(BenchmarkId::new("cobs", set), data, move |b, i| {
+            b.iter(|| cobs::encode(i, &mut out));
         });
 
         const FIXED_OUT_LEN: usize = corncobs::max_encoded_len(1024);
@@ -42,7 +42,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         const ELEN: usize = corncobs::max_encoded_len(FIXED_LEN);
         let mut encoded = [0; ELEN];
-        let n = corncobs::encode_buf(data, &mut encoded);
+        let _ = corncobs::encode_buf(data, &mut encoded);
 
         let mut out = [0; FIXED_LEN];
         group.bench_with_input(BenchmarkId::new("corncobs", set), &encoded, move |b, i| {
@@ -53,14 +53,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| cobs_rs::unstuff::<ELEN, FIXED_LEN>(*i, corncobs::ZERO));
         });
 
-        // postcard-cobs loses its _mind_ if you hand it data including a zero,
-        // i.e.
-        //
-        // assertion failed: dec.push(source).or(Err(()))?.is_none()
-        let trimmed = &encoded[..n - 1];
         let mut out = [0; FIXED_LEN];
-        group.bench_with_input(BenchmarkId::new("postcard-cobs", set), trimmed, move |b, i| {
-            b.iter(|| postcard_cobs::decode(i, &mut out));
+        group.bench_with_input(BenchmarkId::new("cobs", set), &encoded, move |b, i| {
+            b.iter(|| cobs::decode(i, &mut out));
         });
 
     }

--- a/fuzzing/Cargo.toml
+++ b/fuzzing/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 corncobs = {path = ".."}
 honggfuzz = "0.5"
-postcard-cobs = "0.2"
+cobs = "0.2.1"

--- a/fuzzing/src/bin/decode_pc.rs
+++ b/fuzzing/src/bin/decode_pc.rs
@@ -1,4 +1,4 @@
-//! Fuzz test for postcard-cobs, to check whether I was simply holding it wrong
+//! Fuzz test for cobs, to check whether I was simply holding it wrong
 //! or if it really does panic freely.
 
 use honggfuzz::fuzz;
@@ -7,7 +7,7 @@ fn main() {
     loop {
         fuzz!(|data: &[u8]| {
             let mut out = data.to_vec();
-            postcard_cobs::decode(data, &mut out).ok();
+            cobs::decode(data, &mut out).ok();
         });
     }
 }

--- a/tests/compat.rs
+++ b/tests/compat.rs
@@ -59,9 +59,13 @@ fn check_cobs_rs() {
 }
 
 #[test]
-fn check_postcard_cobs() {
+fn check_cobs() {
     for (i, (input, _output)) in FIXTURES.iter().enumerate() { 
         let skips = [0];
+
+        // NOTE: `cobs` does not support zero-length messages. Rather than
+        // serializing an empty message, e.g. `[0x01, 0x00]`, it produces
+        // an empty serialized message, e.g. `[]`.
         if skips.contains(&i) {
             eprintln!("skipping known-broken fixture {}", i);
             continue;
@@ -74,15 +78,15 @@ fn check_postcard_cobs() {
         eprintln!("corncobs: {:x?}", ccout);
 
         let mut actual = vec![0; corncobs::max_encoded_len(input.len())];
-        let pclen = postcard_cobs::encode(input, &mut actual);
+        let pclen = cobs::encode(input, &mut actual);
         let pcout = &actual[..pclen];
-        eprintln!("postcard: {:x?}", pcout);
+        eprintln!("cobs: {:x?}", pcout);
 
         for (j, (ours, theirs)) in ccout.iter().zip(pcout).enumerate() {
             assert_eq!(theirs, ours, "mismatch at fixture {} index {}", i, j);
         }
 
-        // Postcard does not zero-terminate.
+        // cobs.rs does not zero-terminate.
         assert_eq!(pcout.len(), ccout.len() - 1, "length mismatch at fixture {}", i);
     }
 }


### PR DESCRIPTION
Hi there @cbiffle, I've been working on re-mainlining `postcard-cobs` into `cobs.rs`/`cobs`.

I've released v0.2.1, which addresses the panics you mentioned (e.g. "losing it's mind"). It will now gracefully decode with an included zero terminator, or with a full message missing just the zero terminator at the end (for back-compat).

I'm happy to provide any more information or context you were missing in your readme, but it reads more as an opinion piece at a snapshot in time, so it didn't seem right for me to update it.

I wasn't able to run the fuzzing tests, but hopefully they may now work as well.