### PR TITLE
Fix encode_buf when a maximal-length run is immediately followed by a zero

### DIFF
--- a/fuzzing/src/bin/encode_buf_matches_encode_iter.rs
+++ b/fuzzing/src/bin/encode_buf_matches_encode_iter.rs
@@ -1,0 +1,14 @@
+use honggfuzz::fuzz;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let mut out0 = vec![0; corncobs::max_encoded_len(data.len())];
+            let n = corncobs::encode_buf(data, &mut out0);
+
+            let out1: Vec<u8> = corncobs::encode_iter(data).collect();
+
+            assert_eq!(&out0[..n], out1);
+        });
+    }
+}

--- a/fuzzing/src/bin/roundtrip_in_place.rs
+++ b/fuzzing/src/bin/roundtrip_in_place.rs
@@ -1,0 +1,12 @@
+use honggfuzz::fuzz;
+
+fn main() {
+    loop {
+        fuzz!(|data: &[u8]| {
+            let mut out = vec![0; corncobs::max_encoded_len(data.len())];
+            let n = corncobs::encode_buf(data, &mut out);
+            let m = corncobs::decode_in_place(&mut out[..n]).unwrap();
+            assert_eq!(data, &out[..m]);
+        });
+    }
+}


### PR DESCRIPTION
Prior to this change, `encode_buf()` would erroneously omit an encoded zero byte if that zero byte was immediately preceded by a `MAX_LEN`-length run. In addition to a fix, this PR adds:

* A test fixture with a buffer that triggers this case
* A fuzz test comparing `encode_buf` against `encode_iter` (which handled this case correctly)
* A fuzz test that round trips through `encode_buf` and `decode_in_place`
